### PR TITLE
Xamarin.Android guide

### DIFF
--- a/tutorials/xamarin-android-msbuild
+++ b/tutorials/xamarin-android-msbuild
@@ -1,0 +1,54 @@
+Xamarin Android MSBuild Example
+===============================
+
+By Edward Brey
+
+This page shows how to automate Obfuscar for Xamarin.Android using MSBuild. MSBuild integration for other platforms is similar.
+
+.. contents:: In this article:
+  :local:
+  :depth: 1
+
+Nuget Package
+----------------
+Install the Obfuscar NuGet package into the Xamarin Android project.
+
+``` powershell
+Install-Package Obfuscar
+```
+
+Project file
+------------
+In the Xamarin Android project file (.csproj), add an `AfterBuild` target to run the obfuscator.
+
+The obfusctaor runs from `MonoAndroidIntermediateAssetsDir`, which is the assets directory that gets bundled into the APK.
+An example of this directory is `obj\Release\90\android\assets`.
+
+The obfusctaor outputs to the target directory (e.g. `bin\Release`) so that the mapping file will go there.
+It then copies the obfuscated files to the assets directory.
+
+This is an example target for obfuscating a single assembly called `MyAssembly.dll`:
+``` xml
+<Target Name="AfterBuild" Condition=" '$(Configuration)' == 'Release' ">
+  <Exec WorkingDirectory="$(MonoAndroidIntermediateAssetsDir)" Command="$(Obfuscar) $(ProjectDir)obfuscar.xml" />
+  <Copy SourceFiles="$(TargetDir)MyAssembly.dll" DestinationFolder="$(MonoAndroidIntermediateAssetsDir)" />
+</Target>
+```
+
+Obfuscar configuration file
+---------------------------
+Create `obfuscar.xml` in the Xamarin Android project.
+Configure it to output to the target directory relative to the assets directory.
+
+``` xml
+<Obfuscator>
+	<Var name="OutPath" value="..\..\..\..\..\bin\Release" />
+	<Module file="MyAssembly.dll" />
+</Obfuscator>
+```
+
+Related Resources
+-----------------
+
+- :doc:`/getting-started/configuration`
+- :doc:`/support/services`


### PR DESCRIPTION
Documents #1.

The `..\..\..\..\..\bin\Release` path in `obfuscar.xml` is ugly. Ideally, obfuscar.exe would take parameters for the paths so that the MSBuild properties could be used. Or even better would be if obfuscar were distributed as a .NET Standard DLL that could be executed as a MSBuild task directly. Then it could be used to build on Mac as well.