### PR TITLE
Additional Xamarin Android information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This document is derived from ASP.NET 5 [Contributing Guide](https://github.com/aspnet/Docs/blob/master/CONTRIBUTING.md).
 
-Information on contributing to this repo is in the [Contributing Guide](https://github.com/dockpanelsuite/dockpanelsuite/blob/dev/CONTRIBUTING.md) in the Home repo.
+Information on contributing to this repo is in the [Contributing Guide](https://github.com/obfuscar/docs/blob/master/CONTRIBUTING.md) in the Home repo.
 
 The documentation is built using [Sphinx](http://sphinx-doc.org) and [reStructuredText](http://sphinx-doc.org/rest.html).
 
@@ -84,15 +84,15 @@ Author information should be placed in the _authors folder following the example
 
 **Step 1:** Open an Issue describing the article you wish to write and how it relates to existing content. Get approval to write your article.
 
-**Step 2:** Fork the `/dockpanelsuite_docs` repo.
+**Step 2:** Fork the `/docs` repo.
 
 **Step 3:** Create a `branch` for your article.
 
 **Step 4:** Write your article, placing the article in its own folder and any needed images in a _static folder located in the same folder as the article. If you have code samples, place them in a folder within the `/samples/` folder.
 
-**Step 5:** Submit a Pull Request from your branch to `dockpanelsuite_docs/master`.
+**Step 5:** Submit a Pull Request from your branch to `docs/master`.
 
-**Step 6:** Discuss the Pull Request with the DockPanel Suite maintainers; make any requested updates to your branch. When they are ready to accept the PR, they will add a :shipit: (`:shipit:`) comment.
+**Step 6:** Discuss the Pull Request with the Obfuscar maintainers; make any requested updates to your branch. When they are ready to accept the PR, they will add a :shipit: (`:shipit:`) comment.
 
 **Step 7:** The last step before your Pull Request is accepted is to [squash all commits](https://stackoverflow.com/questions/14534397/squash-all-my-commits-into-one-for-github-pull-request) into a single commit message. Do this in your branch, using the `rebase` git command. For example, if you want to squash the last 4 commits into a single commit, you would use:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Obfuscar Docs
 ====================
 
-This project provides the source for [docs.obfuscar.com](https://docs.obfuscar.com/). You can learn more about Obfuscar at the [Home](https://github.com/lextm/obfuscar) repo.
+This project provides the source for [docs.obfuscar.com](https://docs.obfuscar.com/). You can learn more about Obfuscar at the [Home](https://github.com/obfuscar/obfuscar) repo.
 
 **We accept pull requests!** However, before submitting a pull request, please [read the CONTRIBUTING guidelines](CONTRIBUTING.md), which include information on how to build the docs locally, as well as style and organizational guidance.

--- a/tutorials/xamarin.rst
+++ b/tutorials/xamarin.rst
@@ -1,7 +1,7 @@
 Information on Xamarin.Android
 ==============================
 
-By Edward Brey
+By Edward Brey and Ronan Burke
 
 This page shows how to automate Obfuscar for Xamarin.Android using MSBuild.
 Integration for other Xamarin platforms is similar.
@@ -40,6 +40,8 @@ This is an example target for obfuscating a single assembly called
     <Exec WorkingDirectory="$(MonoAndroidIntermediateAssetsDir)" Command="$(Obfuscar) $(ProjectDir)obfuscar.xml" />
     <Copy SourceFiles="$(TargetDir)MyAssembly.dll" DestinationFolder="$(MonoAndroidIntermediateAssetsDir)" />
   </Target>
+  
+It is a good idea to `place this near the bottom <https://stackoverflow.com/a/40348862/3991315>`_ of your project file after all other targets to ensure it is run.
 
 Obfuscar Configuration File
 ---------------------------
@@ -52,6 +54,74 @@ to the target directory relative to the assets directory.
     <Var name="OutPath" value="..\..\..\..\..\bin\Release" />
     <Module file="MyAssembly.dll" />
   </Obfuscator>
+  
+Troubleshooting
+---------------
+To more effectively troubleshoot issues, you can use the following tools/methods:
+
+- Temporarily change the ``AfterBuild`` target mentioned above to be for the 'Debug' configuration. Add a debug message to the configuration so you can confirm the task is being run:
+
+.. code-block:: xml
+
+  <Target Name="AfterBuild" Condition=" '$(Configuration)' == 'Debug' ">
+	<Message Importance="High" Text="Obfuscar task has been called." />
+    <Exec WorkingDirectory="$(MonoAndroidIntermediateAssetsDir)" Command="$(Obfuscar) $(ProjectDir)obfuscar.xml" />
+    <Copy SourceFiles="$(TargetDir)MyAssembly.dll" DestinationFolder="$(MonoAndroidIntermediateAssetsDir)" />
+  </Target>
+
+Update ``obfuscar.xml`` to output to the Debug folder:
+
+.. code-block:: xml
+
+    <Var name="OutPath" value="..\..\..\..\..\bin\Debug" />
+  
+- Run your application in Debug mode. In Visual Studio, go to ``Debug > Windows > Exception Settings``. Enable ``Common Language Runtime Exceptions``. When your app runs, this will allow you to see if you are getting any new exceptions when obfuscation is enabled.
+- If your app crashes on startup with no obvious exceptions, go to ``Tools > Android > Device Log...`` and use the messages from Logcat to diagnose/research the errors you get.
+
+Linking issues
+**************
+
+With linking enabled, you may get this error message:
+
+::
+
+	XALNK7000: Java.Interop.Tools.Diagnostics.XamarinAndroidException: error XA2006: Could not resolve reference to ' . '
+	...
+	When the scope is different from the defining assembly, it usually means that the type is forwarded. ---> Mono.Cecil.ResolutionException: Failed to resolve  .
+
+With linking disabled, you may get this error message:
+
+::
+
+	JAVAC0000:  error: illegal character: '\u2006' xamarin forms
+
+The above two errors can be resolved by using this property in ``obfuscar.xml``:
+
+.. code-block:: xml
+
+	<Var name="UseUnicodeNames" value="false" />
+
+AndroidX issues
+***************
+
+Using Obfuscar can reveal issues with an improper AndroidX migration in Xamarin. If you get an error like this:
+
+::
+
+	System.InvalidCastException: Unable to convert instance of type 'Google.Android.Material.Internal.CheckableImageButton' to type 'AndroidX.AppCompat.Widget.Toolbar'
+	
+You should update "android.support.v7.widget.Toolbar" to "androidx.appcompat.widget.Toolbar" in ``Toolbar.xml``. You should rename the file to ``Toolbar.axml``. You should update "android.support.design.widget.TabLayout" to "com.google.android.material.tabs.TabLayout" in ``Tabbar.xml``. You should rename the file to ``Tabbar.axml``.
+
+The `Xamarin.Forms team recomend removing these files altogether <https://docs.microsoft.com/en-us/xamarin/xamarin-forms/troubleshooting/questions/forms5-migration#remove-axml-files>`_, but you may encounter other issues when running your Android app after doing this. 
+
+Dependency injection errors
+***************************
+
+If you are using dependency injection and are getting dependency injection errors, ensure public items are kept in ``obfuscar.xml``:
+
+.. code-block:: xml
+
+	<Var name="KeepPublicApi" value="true" />
 
 Related Resources
 -----------------


### PR DESCRIPTION
I recently added Obfuscar to my Xamarin.Forms/Xamarin.Android app. There isn't a huge amount of documentation or examples of this on the web. I encountered some issues when setting it up in a more advanced scenarios with linking, AndroidX, dependency injection so I thought it would be good to post solutions to the errors I encountered.

Summary of changes:
- Clarify where to place your `Target` in the .csproj file
- Adds a Troubleshooting section to the Xamarin.Android Page
  - How to troubleshoot better
  - Common Xamarin.Android obfuscation issues
- Updates main repo link to point to the correct repo
- Removes references to DockPanel Suite in contributing guidelines